### PR TITLE
Document transcript language parameter usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Model Context Protocol (MCP) server implementation for YouTube, enabling AI la
 
 ### Transcript Management
 * Retrieve video transcripts
-* Support for multiple languages
+* Planned support for multiple languages
 * Get timestamped captions
 * Search within transcripts
 
@@ -47,7 +47,8 @@ npm install zubeid-youtube-mcp-server
 ## Configuration
 Set the following environment variables:
 * `YOUTUBE_API_KEY`: Your YouTube Data API key
-* `YOUTUBE_TRANSCRIPT_LANG`: Default language for transcripts (optional, defaults to 'en')
+* `YOUTUBE_TRANSCRIPT_LANG`: Default language for transcripts (optional, defaults to 'en').
+  Currently unused and reserved for future support of transcript languages.
 
 ## Using with MCP Client
 Add this to your MCP client configuration (e.g. Claude Desktop):
@@ -143,8 +144,8 @@ const video = await youtube.videos.getVideo({
 
 // Get video transcript
 const transcript = await youtube.transcripts.getTranscript({
-  videoId: "video-id",
-  language: "en"
+  videoId: "video-id"
+  // `language` can be provided but is currently ignored
 });
 
 // Search videos

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,8 @@ This server can be deployed in two ways:
 
 The server requires the following environment variables:
 - `YOUTUBE_API_KEY`: Your YouTube Data API key (required)
-- `YOUTUBE_TRANSCRIPT_LANG`: Default language for transcripts (optional, defaults to 'en')
+- `YOUTUBE_TRANSCRIPT_LANG`: Default language for transcripts (optional, defaults to 'en').
+  Currently unused and reserved for future support of transcript languages.
 
 ## API Endpoints
 

--- a/src/services/transcript.ts
+++ b/src/services/transcript.ts
@@ -19,7 +19,12 @@ export class TranscriptService {
   }
 
   /**
-   * Get the transcript of a YouTube video
+   * Get the transcript of a YouTube video.
+   *
+   * Note: The `language` parameter is accepted for API
+   *       consistency but is currently ignored. The
+   *       transcript is returned in the default language
+   *       provided by YouTube.
    */
   async getTranscript({ 
     videoId, 
@@ -42,7 +47,10 @@ export class TranscriptService {
   }
 
   /**
-   * Search within a transcript
+   * Search within a transcript.
+   *
+   * The `language` parameter is currently ignored and
+   * all searches are performed on the default transcript.
    */
   async searchTranscript({ 
     videoId, 
@@ -71,7 +79,11 @@ export class TranscriptService {
   }
   
   /**
-   * Get transcript with timestamps
+   * Get transcript with timestamps.
+   *
+   * The `language` option is ignored; timestamps are
+   * generated from the default transcript returned by
+   * YouTube.
    */
   async getTimestampedTranscript({ 
     videoId, 

--- a/youtube-mcp-readme.md
+++ b/youtube-mcp-readme.md
@@ -11,7 +11,7 @@ A Model Context Protocol (MCP) server implementation for YouTube, enabling AI la
 
 ### Transcript Management
 * Retrieve video transcripts
-* Support for multiple languages
+* Planned support for multiple languages
 * Get timestamped captions
 * Search within transcripts
 
@@ -36,7 +36,8 @@ npm install @modelcontextprotocol/server-youtube
 ## Configuration
 Set the following environment variables:
 * `YOUTUBE_API_KEY`: Your YouTube Data API key
-* `YOUTUBE_TRANSCRIPT_LANG`: Default language for transcripts (optional, defaults to 'en')
+* `YOUTUBE_TRANSCRIPT_LANG`: Default language for transcripts (optional, defaults to 'en').
+  Currently unused and reserved for future support of transcript languages.
 
 ## Using with MCP Client
 Add this to your MCP client configuration (e.g. Claude Desktop):
@@ -134,8 +135,8 @@ const video = await youtube.videos.getVideo({
 
 // Get video transcript
 const transcript = await youtube.transcripts.getTranscript({
-  videoId: "video-id",
-  language: "en"
+  videoId: "video-id"
+  // `language` can be provided but is currently ignored
 });
 
 // Search videos

--- a/youtube-readme.md
+++ b/youtube-readme.md
@@ -11,7 +11,7 @@ A Model Context Protocol (MCP) server implementation for YouTube, enabling AI la
 
 ### Transcript Management
 * Retrieve video transcripts
-* Support for multiple languages
+* Planned support for multiple languages
 * Get timestamped captions
 * Search within transcripts
 
@@ -36,7 +36,8 @@ npm install @modelcontextprotocol/server-youtube
 ## Configuration
 Set the following environment variables:
 * `YOUTUBE_API_KEY`: Your YouTube Data API key
-* `YOUTUBE_TRANSCRIPT_LANG`: Default language for transcripts (optional, defaults to 'en')
+* `YOUTUBE_TRANSCRIPT_LANG`: Default language for transcripts (optional, defaults to 'en').
+  Currently unused and reserved for future support of transcript languages.
 
 ## Using with MCP Client
 Add this to your MCP client configuration (e.g. Claude Desktop):
@@ -73,8 +74,8 @@ const video = await youtube.videos.getVideo({
 
 // Get video transcript
 const transcript = await youtube.transcripts.getTranscript({
-  videoId: "video-id",
-  language: "en"
+  videoId: "video-id"
+  // `language` can be provided but is currently ignored
 });
 
 // Search videos


### PR DESCRIPTION
## Summary
- update transcript service comments to clarify `language` parameter is ignored
- mention planned multi-language support in docs
- mark `YOUTUBE_TRANSCRIPT_LANG` as unused across docs
- update example code snippets

## Testing
- `npm run build` *(fails: Cannot find name 'process' and missing modules)*