### PR TITLE
Add Jest tests for services

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.ts']
+};

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "start": "ts-node ./src/index.ts",
     "build": "tsc",
     "dev": "nodemon ./src/index.ts",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "test": "jest"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.1.1",
@@ -27,7 +28,9 @@
     "@types/node": "^18.0.0",
     "typescript": "^5.0.0",
     "ts-node": "^10.9.1",
-    "nodemon": "^3.0.0"
+    "nodemon": "^3.0.0",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0"
   },
   "keywords": [
     "youtube",

--- a/tests/services/channelService.test.ts
+++ b/tests/services/channelService.test.ts
@@ -1,0 +1,23 @@
+import { ChannelService } from '../../src/services/channel';
+
+const mockChannelsList = jest.fn();
+const mockYoutube = {
+  channels: { list: mockChannelsList }
+};
+
+jest.mock('googleapis', () => ({
+  google: {
+    youtube: jest.fn(() => mockYoutube)
+  }
+}));
+
+describe('ChannelService.getChannel', () => {
+  it('채널 정보를 받아와야 한다', async () => {
+    process.env.YOUTUBE_API_KEY = 'test-key';
+    mockChannelsList.mockResolvedValue({ data: { items: [{ id: 'ch1' }] } });
+    const service = new ChannelService();
+    const result = await service.getChannel({ channelId: 'ch1' });
+    expect(result).toEqual({ id: 'ch1' });
+    expect(mockChannelsList).toHaveBeenCalled();
+  });
+});

--- a/tests/services/playlistService.test.ts
+++ b/tests/services/playlistService.test.ts
@@ -1,0 +1,23 @@
+import { PlaylistService } from '../../src/services/playlist';
+
+const mockPlaylistsList = jest.fn();
+const mockYoutube = {
+  playlists: { list: mockPlaylistsList }
+};
+
+jest.mock('googleapis', () => ({
+  google: {
+    youtube: jest.fn(() => mockYoutube)
+  }
+}));
+
+describe('PlaylistService.getPlaylist', () => {
+  it('플레이리스트 정보를 반환해야 한다', async () => {
+    process.env.YOUTUBE_API_KEY = 'test-key';
+    mockPlaylistsList.mockResolvedValue({ data: { items: [{ id: 'pl1' }] } });
+    const service = new PlaylistService();
+    const result = await service.getPlaylist({ playlistId: 'pl1' });
+    expect(result).toEqual({ id: 'pl1' });
+    expect(mockPlaylistsList).toHaveBeenCalled();
+  });
+});

--- a/tests/services/transcriptService.test.ts
+++ b/tests/services/transcriptService.test.ts
@@ -1,0 +1,21 @@
+import { TranscriptService } from '../../src/services/transcript';
+
+const fetchTranscriptMock = jest.fn();
+
+jest.mock('youtube-transcript', () => ({
+  YoutubeTranscript: { fetchTranscript: fetchTranscriptMock }
+}));
+
+describe('TranscriptService.getTranscript', () => {
+  it('트랜스크립트를 반환해야 한다', async () => {
+    fetchTranscriptMock.mockResolvedValue([{ text: 'hello', offset: 0, duration: 1 }]);
+    const service = new TranscriptService();
+    const result = await service.getTranscript({ videoId: 'v1' });
+    expect(result).toEqual({
+      videoId: 'v1',
+      language: 'en',
+      transcript: [{ text: 'hello', offset: 0, duration: 1 }]
+    });
+    expect(fetchTranscriptMock).toHaveBeenCalledWith('v1');
+  });
+});

--- a/tests/services/videoService.test.ts
+++ b/tests/services/videoService.test.ts
@@ -1,0 +1,24 @@
+import { VideoService } from '../../src/services/video';
+
+const mockVideosList = jest.fn();
+const mockYoutube = {
+  videos: { list: mockVideosList },
+  search: { list: jest.fn() }
+};
+
+jest.mock('googleapis', () => ({
+  google: {
+    youtube: jest.fn(() => mockYoutube)
+  }
+}));
+
+describe('VideoService.getVideo', () => {
+  it('정상적으로 비디오 정보를 반환해야 한다', async () => {
+    process.env.YOUTUBE_API_KEY = 'test-key';
+    mockVideosList.mockResolvedValue({ data: { items: [{ id: 'abc' }] } });
+    const service = new VideoService();
+    const result = await service.getVideo({ videoId: 'abc' });
+    expect(result).toEqual({ id: 'abc' });
+    expect(mockVideosList).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest and ts-jest setup
- include `npm test` script
- create service tests with mocked YouTube API

## Testing
- `npm test` *(fails: jest not found)*